### PR TITLE
fix(ci): repair Lint & Format and Type Check jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Install dependencies
+        run: uv sync --all-extras
+
       - name: Check formatting with ruff
         run: uv run ruff format --check src/ tests/
 

--- a/src/git_gud_samaritans/discovery/github_scanner.py
+++ b/src/git_gud_samaritans/discovery/github_scanner.py
@@ -56,7 +56,7 @@ class GitHubScanner:
     def _check_rate_limit(self) -> None:
         """Check and log current rate limit status."""
         rate_limit = self.client.get_rate_limit()
-        core = rate_limit.core
+        core = rate_limit.resources.core
 
         logger.info(
             "github_rate_limit",


### PR DESCRIPTION
## Problem

Two CI jobs fail on the default branch (`master`), and Dependabot PR #15 (python-dotenv bump) inherits these failures, blocking it from merging. The Node.js 20 deprecation warning in the logs is unrelated noise.

## Root causes

### Lint & Format (exit 1)
```
error: Failed to spawn: `ruff`
  Caused by: No such file or directory (os error 2)
```
The job runs `uv run ruff format --check` / `uv run ruff check` but never installs project dependencies. `ruff` is declared in the `dev` optional-dependencies extra, so `uv run` builds the package with only its main dependencies and `ruff` is never on `PATH`.

### Type Check (exit 1)
```
src/git_gud_samaritans/discovery/github_scanner.py:59: error: "RateLimitOverview" has no attribute "core"  [attr-defined]
```
PyGithub 2.x changed `Github.get_rate_limit()` to return a `RateLimitOverview` whose individual resources are nested under `.resources` (a `RateLimit` object). The old top-level `.core` attribute no longer exists.

## Fix

- **ci.yml**: add a `uv sync --all-extras` step to the Lint & Format job (mirrors the Type Check job, which already had it).
- **github_scanner.py**: change `rate_limit.core` to `rate_limit.resources.core`.

## Verification (local)

```
uv run ruff format --check src/ tests/   # 36 files already formatted
uv run ruff check src/ tests/            # All checks passed!
uv run mypy src/                         # Success: no issues found in 18 source files
```

Unblocks Dependabot PR #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)