### PR TITLE
test: fix rate-limit mocks for PyGithub 2.x (unblocks Test CI jobs)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,9 @@ def mock_github_client() -> MagicMock:
 
     # Mock rate limit
     rate_limit = MagicMock()
-    rate_limit.core.remaining = 5000
-    rate_limit.core.limit = 5000
-    rate_limit.core.reset.isoformat.return_value = "2024-01-01T00:00:00"
+    rate_limit.resources.core.remaining = 5000
+    rate_limit.resources.core.limit = 5000
+    rate_limit.resources.core.reset.isoformat.return_value = "2024-01-01T00:00:00"
     client.get_rate_limit.return_value = rate_limit
 
     return client

--- a/tests/test_discovery/test_github_scanner.py
+++ b/tests/test_discovery/test_github_scanner.py
@@ -45,9 +45,11 @@ class TestGitHubScanner:
         """Scanner should initialize with environment token."""
         mock_client = MagicMock()
         mock_rate_limit = MagicMock()
-        mock_rate_limit.core.remaining = 5000
-        mock_rate_limit.core.limit = 5000
-        mock_rate_limit.core.reset.isoformat.return_value = "2024-01-01T00:00:00"
+        mock_rate_limit.resources.core.remaining = 5000
+        mock_rate_limit.resources.core.limit = 5000
+        mock_rate_limit.resources.core.reset.isoformat.return_value = (
+            "2024-01-01T00:00:00"
+        )
         mock_client.get_rate_limit.return_value = mock_rate_limit
         mock_github.return_value = mock_client
 
@@ -60,9 +62,11 @@ class TestGitHubScanner:
         """Scanner should initialize with explicit token."""
         mock_client = MagicMock()
         mock_rate_limit = MagicMock()
-        mock_rate_limit.core.remaining = 5000
-        mock_rate_limit.core.limit = 5000
-        mock_rate_limit.core.reset.isoformat.return_value = "2024-01-01T00:00:00"
+        mock_rate_limit.resources.core.remaining = 5000
+        mock_rate_limit.resources.core.limit = 5000
+        mock_rate_limit.resources.core.reset.isoformat.return_value = (
+            "2024-01-01T00:00:00"
+        )
         mock_client.get_rate_limit.return_value = mock_rate_limit
         mock_github.return_value = mock_client
 
@@ -80,9 +84,11 @@ class TestGitHubScanner:
         """Scanner should search for issues."""
         mock_client = MagicMock()
         mock_rate_limit = MagicMock()
-        mock_rate_limit.core.remaining = 5000
-        mock_rate_limit.core.limit = 5000
-        mock_rate_limit.core.reset.isoformat.return_value = "2024-01-01T00:00:00"
+        mock_rate_limit.resources.core.remaining = 5000
+        mock_rate_limit.resources.core.limit = 5000
+        mock_rate_limit.resources.core.reset.isoformat.return_value = (
+            "2024-01-01T00:00:00"
+        )
         mock_client.get_rate_limit.return_value = mock_rate_limit
 
         # Mock issue search results


### PR DESCRIPTION
## Problem

After #16 fixed the source to use PyGithub 2.x's `rate_limit.resources.core`, the `Test (Python 3.10/3.11/3.12)` CI jobs failed:

```
TypeError: '<' not supported between instances of 'MagicMock' and 'int'
```

The test mocks (`tests/conftest.py` and `tests/test_discovery/test_github_scanner.py`) still mocked the old `rate_limit.core.*` path, so `rate_limit.resources.core.remaining` resolved to a bare `MagicMock` that the scanner then compared against an int.

## Fix

Update the four mock blocks to set `rate_limit.resources.core.*`.

## Verification

- `uv run pytest` — **112 passed**
- `ruff check` / `ruff format --check` — clean

Unblocks Dependabot PR #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)